### PR TITLE
Reduce gate correction zone of influence

### DIFF
--- a/competition/mpcc_controller.py
+++ b/competition/mpcc_controller.py
@@ -63,7 +63,7 @@ class MPCCController():
         def deg_to_rad(d): return d * 2 * m.pi / 180.0
 
         self.MPCC_CONTOUR_ERROR_GAUSSIAN_SIGMA = 0.4  # m
-        self.MPCC_GATEWAY_CORRECTION_PATCH_SIGMA = 1.0  # m
+        self.MPCC_GATEWAY_CORRECTION_PATCH_SIGMA = 0.4  # m
 
         self.MPCC_SPEED_BUMP_K = 5.0  # unit-less gain
         self.MPCC_SPEED_BUMP_TRESHOLD = 1.2  # m/s


### PR DESCRIPTION
Precisely what the title says. This gets rid of collisions on scenarios 1310 and 1396.